### PR TITLE
4381 retention rule api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
                     <!-- Keep your maven submodules at the same version as the parent POM -->
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <!--
-                      Pusing in-development features to origin allows all devs to see what each other
+                      Pushing in-development features to origin allows all devs to see what each other
                       are working on
                     -->
                     <pushFeatures>true</pushFeatures>

--- a/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsPlatform.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsPlatform.java
@@ -14,6 +14,7 @@ import com.telekom.m2m.cot.restsdk.event.EventApi;
 import com.telekom.m2m.cot.restsdk.identity.IdentityApi;
 import com.telekom.m2m.cot.restsdk.inventory.InventoryApi;
 import com.telekom.m2m.cot.restsdk.measurement.MeasurementApi;
+import com.telekom.m2m.cot.restsdk.retentionrule.RetentionRuleApi;
 import com.telekom.m2m.cot.restsdk.users.UsersApi;
 
 import okhttp3.OkHttpClient;
@@ -215,4 +216,14 @@ public class CloudOfThingsPlatform {
 	public AuditApi getAuditApi() {
 		return new AuditApi(cloudOfThingsRestClient);
 	}
+
+	/**
+	 * Returns the object to work with the retention rules API.
+	 *
+	 * @return ready to use RetentionRuleApi object.
+	 */
+	public RetentionRuleApi getRetentionRuleApi() {
+		return new RetentionRuleApi(cloudOfThingsRestClient);
+	}
+
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsPlatform.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsPlatform.java
@@ -19,7 +19,7 @@ import com.telekom.m2m.cot.restsdk.users.UsersApi;
 import okhttp3.OkHttpClient;
 
 /**
- * The CloudOfThingsPlatform is the starting point to interfere the Cloud of
+ * The CloudOfThingsPlatform is the starting point to access the Cloud of
  * Things.
  * <p>
  * Created by Patrick Steinert on 30.01.16.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsRestClient.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/CloudOfThingsRestClient.java
@@ -36,7 +36,7 @@ public class CloudOfThingsRestClient {
     }
 
     /**
-     * Proceedes a HTTP POST request and parses the response Header.
+     * Proceeds a HTTP POST request and parses the response Header.
      * Response header 'Location' will be split to get the ID of the object (mostly created).
      *
      * @param json        Request body, needs to be a json object correlating to the contentType.
@@ -72,14 +72,14 @@ public class CloudOfThingsRestClient {
         } catch (CotSdkException e) {
             throw e;
         } catch (Exception e) {
-            throw new CotSdkException("Problem", e);
+            throw new CotSdkException("Problem: " + e.getMessage(), e);
         } finally {
             closeResponseBodyIfResponseAndBodyNotNull(response);
         }
     }
 
     /**
-     * Proceedes a HTTP POST request and returns the response body as String.
+     * Proceeds a HTTP POST request and returns the response body as String.
      *
      * @param json        Request body, needs to be a json object correlating to the contentType.
      * @param api         the REST API string.
@@ -113,7 +113,7 @@ public class CloudOfThingsRestClient {
     }
 
     /**
-     * Proceedes a HTTP POST request and returns the response body as String.
+     * Proceeds a HTTP POST request and returns the response body as String.
      * Method will throw an exception if the response code is indicating
      * a non successfull request.
      *

--- a/src/main/java/com/telekom/m2m/cot/restsdk/event/EventApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/event/EventApi.java
@@ -28,10 +28,10 @@ public class EventApi {
     }
 
     /**
-     * Retrives a specific Event.
+     * Retrieves a specific Event.
      *
      * @param eventId the unique identifier of the desired Event.
-     * @return the Event (or null if not found).
+     * @return the Event (or null if not found). TODO: it does _not_ return null. But maybe it should.
      */
     public Event getEvent(String eventId) {
         String response = cloudOfThingsRestClient.getResponse(eventId, RELATIVE_API_URL, CONTENT_TYPE);
@@ -40,7 +40,7 @@ public class EventApi {
     }
 
     /**
-     * Stores a Event.
+     * Stores an Event.
      *
      * @param event the event to create.
      * @return the created event with the assigned unique identifier.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObject.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObject.java
@@ -8,14 +8,14 @@ import java.util.Date;
 /**
  * Represents a ManagedObject from the platform.
  * <p>
- * The ManagedObject can be model any physical or cyber-physical object, even virtual object.
+ * The ManagedObject can model any physical or cyber-physical object, even virtual object.
  * <p>
  * Created by Patrick Steinert on 30.01.16.
  */
 public class ManagedObject extends ExtensibleObject {
 
     /**
-     * Default construction to create a new managed objects.
+     * Default construction to create a new managed object.
      */
     public ManagedObject() {
         super();

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
@@ -1,0 +1,187 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
+
+
+/**
+ * RetentionRules govern after what time old data is to be removed from the cloud.
+ * Each type of document can have it's own rule, so that some types can be kept longer,
+ * while others get cleaned up faster.
+ */
+public class RetentionRule extends ExtensibleObject {
+
+
+    /**
+     * Default constructor to create a new rule.
+     */
+    public RetentionRule() {
+        super();
+    }
+
+    /**
+     * Internal constructor to create rules from base class.
+     *
+     * @param extensibleObject object from base class.
+     */
+    RetentionRule(ExtensibleObject extensibleObject) {
+        super(extensibleObject);
+    }
+
+
+    /**
+     * Get the unique identifier of the rule.
+     * If the rule was retrieved from the platform, it has an ID. If just
+     * created, there is no ID.
+     * TODO: verify whether/why this is a number and not a String as in other entities.
+     *
+     * @return Long the unique identifier of the rule or null if not available.
+     */
+    public Long getId() {
+        Object id = anyObject.get("id");
+        try {
+            return (id instanceof Number) ? ((Number) id).longValue() : (Long) id;
+        } catch (ClassCastException | NullPointerException ex) {
+            // TODO: is there really no better way? The untyped anyObject-Map makes it hard to know what
+            //       we can expect here and it wouldn't be nice to explicitly rely on gson here.
+            return null;
+        }
+    }
+
+    /**
+     * Set the unique identifier of the rule.
+     * Just used internally.
+     *
+     * @param id the new identifier.
+     */
+    void setId(Long id) {
+        anyObject.put("id", id);
+    }
+
+
+    /**
+     * Get the type of the rule.
+     * The type categorizes the rule.
+     *
+     * @return a String with the type or null if not available.
+     */
+    public String getType() {
+        return (String) anyObject.get("type");
+    }
+
+    /**
+     * Setting the rule type.
+     *
+     * @param type a String with the rule type. Use cot_abc_xyz style.
+     */
+    public void setType(String type) {
+        anyObject.put("type", type);
+    }
+
+
+    /**
+     * Get the dataType of the rule.
+     * The type categorizes the rule.
+     *
+     * @return a String with the dataType or null if not available.
+     */
+    public String getDataType() {
+        return (String) anyObject.get("dataType");
+    }
+
+    /**
+     * Setting the rule dataType.
+     *
+     * @param dataType a String with the rule dataType. Use cot_abc_xyz style.
+     */
+    public void setDataType(String dataType) {
+        anyObject.put("dataType", dataType);
+    }
+
+
+    /**
+     * Get the fragmentType of the rule.
+     * The type categorizes the rule.
+     *
+     * @return a String with the fragmentType or null if not available.
+     */
+    public String getFragmentType() {
+        return (String) anyObject.get("fragmentType");
+    }
+
+    /**
+     * Setting the rule fragmentType.
+     *
+     * @param fragmentType a String with the rule fragmentType. Use cot_abc_xyz style.
+     */
+    public void setFragmentType(String fragmentType) {
+        anyObject.put("fragmentType", fragmentType);
+    }
+
+
+    /**
+     * Get the source of the rule.
+     *
+     * TODO: verify whether/why this is a String and not a ManagedObject as in other entities.
+     *
+     * @return a String with the source or null if not available.
+     */
+    public String getSource() {
+        return (String) anyObject.get("source");
+    }
+
+    /**
+     * Setting the rule fragmentType.
+     *
+     * @param source a String with the rule source.
+     */
+    public void setSource(String source) {
+        anyObject.put("source", source);
+    }
+
+
+    /**
+     * Get the maximumAge of the rule.
+     *
+     * @return a Long with the maximumAge (null indicates a parsing problem, because maximumAge is mandatory).
+     */
+    public Long getMaximumAge() {
+        Object maximumAge = anyObject.get("maximumAge");
+        try {
+            return (maximumAge instanceof Number) ? ((Number) maximumAge).longValue() : (long) maximumAge;
+        } catch (ClassCastException | NullPointerException ex) {
+            // TODO: is there really no better way? The untyped anyObject-Map makes it hard to know what
+            //       we can expect here and it wouldn't be nice to explicitly rely on gson here.
+            return null;
+        }
+    }
+
+    /**
+     * Setting the rule maximumAge.
+     *
+     * @param maximumAge a long with the rule maximumAge.
+     */
+    public void setMaximumAge(long maximumAge) {
+        anyObject.put("maximumAge", maximumAge);
+    }
+
+
+    /**
+     * Get the editable-flag of the rule.
+     *
+     * @return the boolean editable-flag
+     */
+    public boolean isEditable() {
+        return (boolean) anyObject.get("editable");
+    }
+
+    /**
+     * Setting the  editable-flag of the rule.
+     *
+     * @param editable flag
+     */
+    public void setEditable(boolean editable) {
+        anyObject.put("editable", editable);
+    }
+
+}
+

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
@@ -177,7 +177,8 @@ public class RetentionRule extends ExtensibleObject {
      * @return the boolean editable-flag
      */
     public boolean isEditable() {
-        return (boolean) anyObject.get("editable");
+        Object editable = anyObject.get("editable");
+        return (editable != null) && (boolean)editable;
     }
 
     /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRule.java
@@ -142,25 +142,31 @@ public class RetentionRule extends ExtensibleObject {
     /**
      * Get the maximumAge of the rule.
      *
-     * @return a Long with the maximumAge (null indicates a parsing problem, because maximumAge is mandatory).
+     * @return an int with the maximumAge
      */
-    public Long getMaximumAge() {
+    public int getMaximumAge() {
         Object maximumAge = anyObject.get("maximumAge");
+        if (maximumAge instanceof Number) {
+            return ((Number) maximumAge).intValue();
+        }
+        if (maximumAge instanceof String) {
+            return Integer.parseInt((String) maximumAge);
+        }
         try {
-            return (maximumAge instanceof Number) ? ((Number) maximumAge).longValue() : (long) maximumAge;
+            return (int) maximumAge;
         } catch (ClassCastException | NullPointerException ex) {
             // TODO: is there really no better way? The untyped anyObject-Map makes it hard to know what
             //       we can expect here and it wouldn't be nice to explicitly rely on gson here.
-            return null;
         }
+        return 0;
     }
 
     /**
      * Setting the rule maximumAge.
      *
-     * @param maximumAge a long with the rule maximumAge.
+     * @param maximumAge an int with the rule maximumAge.
      */
-    public void setMaximumAge(long maximumAge) {
+    public void setMaximumAge(int maximumAge) {
         anyObject.put("maximumAge", maximumAge);
     }
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
@@ -1,8 +1,146 @@
 package com.telekom.m2m.cot.restsdk.retentionrule;
 
+import com.google.gson.Gson;
+import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
+import com.telekom.m2m.cot.restsdk.util.GsonUtils;
+
+import java.util.Map;
+
 
 /**
  * API to create, retrieve, update and delete retention rules.
  */
 public class RetentionRuleApi {
+
+    private static final String CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.retentionRule+json;charset=UTF-8;ver=0.9";
+    private static final String RELATIVE_API_URL = "retention/retentions/";
+
+    private final Gson gson = GsonUtils.createGson();
+    private final CloudOfThingsRestClient cloudOfThingsRestClient;
+
+
+    /**
+     * Internal Constructor.
+     *
+     * @param cloudOfThingsRestClient the configured rest client.
+     */
+    public RetentionRuleApi(CloudOfThingsRestClient cloudOfThingsRestClient) {
+        this.cloudOfThingsRestClient = cloudOfThingsRestClient;
+    }
+
+
+    /**
+     * Retrieves a specific rule.
+     *
+     * @param ruleId the unique identifier of the desired rule.
+     *
+     * @return the RetentionRule (or null if not found).
+     */
+    public RetentionRule getRule(Long ruleId) {
+        String response = cloudOfThingsRestClient.getResponse(ruleId.toString(), RELATIVE_API_URL, CONTENT_TYPE);
+        RetentionRule rule = new RetentionRule(gson.fromJson(response, ExtensibleObject.class));
+        if (rule.getAttributes().size() == 0) {
+            return null;
+        }
+        return rule;
+    }
+
+
+    /**
+     * Stores a rule.
+     *
+     * @param rule the RetentionRule to create. Will be modified but also returned.
+     *              
+     * @return the updated RetentionRule with the assigned unique identifier.
+     */
+    public RetentionRule createRetentionRule(RetentionRule rule) {
+        Map<String, Object> attributes = rule.getAttributes();
+        attributes.remove("id");
+        attributes.remove("editable");
+        ExtensibleObject eo = new ExtensibleObject();
+        eo.setAttributes(attributes);
+        RetentionRule filteredRule = new RetentionRule(eo);
+
+        String json = gson.toJson(filteredRule);
+
+        String id = cloudOfThingsRestClient.doRequestWithIdResponse(json, RELATIVE_API_URL, CONTENT_TYPE);
+        rule.setId(Long.parseLong(id));
+
+        return rule;
+    }
+
+
+    /**
+     * Deletes a rule.
+     *
+     * @param rule the RetentionRule to delete
+     */
+    public void deleteRetentionRule(RetentionRule rule) {
+        cloudOfThingsRestClient.delete(rule.getId().toString(), RELATIVE_API_URL);
+    }
+
+
+    /**
+     * Updates a rule.
+     *
+     * @param rule the rule to update.
+     */
+    public void update(RetentionRule rule) {
+        Map<String, Object> attributes = rule.getAttributes();
+        attributes.remove("id");
+
+        ExtensibleObject extensibleObject = new ExtensibleObject();
+        extensibleObject.setAttributes(attributes);
+
+        String json = gson.toJson(extensibleObject);
+        cloudOfThingsRestClient.doPutRequest(json, RELATIVE_API_URL + rule.getId(), CONTENT_TYPE);
+    }
+
+
+    /**
+     * Retrieves RetentionRules.
+     *
+     * @return the found RetentionRules.
+     */
+    public RetentionRuleCollection getRetentionRules() {
+        return new RetentionRuleCollection(
+                cloudOfThingsRestClient,
+                RELATIVE_API_URL,
+                gson,
+                null);
+    }
+
+
+    /**
+     * Retrieves RetentionRules filtered by criteria.
+     *
+     * @param filters filters of RetentionRule attributes.
+     *
+     * @return the RetentionRuleCollections to navigate through the results.
+     */
+    // TODO: filters do not apply to RetentionRules!?
+    /*
+    public RetentionRuleCollection getRetentionRules(Filter.FilterBuilder filters) {
+        return new RetentionRuleCollection(
+                cloudOfThingsRestClient,
+                RELATIVE_API_URL,
+                gson,
+                filters);
+    }
+    */
+
+
+    /**
+     * Deletes a collection of rules by criteria.
+     *
+     * @param filters filters of RetentionRule attributes.
+     */
+    // TODO: there is no collection-delete endpoint for RetentionRules?
+    /*
+    public void deleteRetentionRules(Filter.FilterBuilder filters) {
+        cloudOfThingsRestClient.delete("", RELATIVE_API_URL + "?" + filters.buildFilter() + "&x=");
+    }
+    */
+
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
@@ -56,8 +56,8 @@ public class RetentionRuleApi {
      */
     public RetentionRule createRetentionRule(RetentionRule rule) {
         Map<String, Object> attributes = rule.getAttributes();
-        attributes.remove("id");
-        attributes.remove("editable");
+        attributes.remove("id"); // Because it feels wrong to ask the server to create an object with a predefined id. It is the server which assigns ids.
+        attributes.remove("editable"); // TODO: is there some way to write this via the REST API?
         ExtensibleObject eo = new ExtensibleObject();
         eo.setAttributes(attributes);
         RetentionRule filteredRule = new RetentionRule(eo);
@@ -80,6 +80,15 @@ public class RetentionRuleApi {
         cloudOfThingsRestClient.delete(rule.getId().toString(), RELATIVE_API_URL);
     }
 
+    /**
+     * Deletes a rule by id.
+     *
+     * @param id the id of the RetentionRule to delete
+     */
+    public void deleteRetentionRule(long id) {
+        cloudOfThingsRestClient.delete(String.valueOf(id), RELATIVE_API_URL);
+    }
+
 
     /**
      * Updates a rule.
@@ -88,7 +97,8 @@ public class RetentionRuleApi {
      */
     public void update(RetentionRule rule) {
         Map<String, Object> attributes = rule.getAttributes();
-        attributes.remove("id");
+        attributes.remove("id"); // It doesn't make sense to change the ID of a rule afterwards.
+        attributes.remove("editable"); // TODO: is there some way to write this via the REST API?
 
         ExtensibleObject extensibleObject = new ExtensibleObject();
         extensibleObject.setAttributes(attributes);

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApi.java
@@ -1,0 +1,8 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+
+/**
+ * API to create, retrieve, update and delete retention rules.
+ */
+public class RetentionRuleApi {
+}

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollection.java
@@ -1,0 +1,49 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
+import com.telekom.m2m.cot.restsdk.util.Filter;
+import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import java.util.stream.StreamSupport;
+
+
+public class RetentionRuleCollection extends JsonArrayPagination {
+
+    private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.retentionRuleCollection+json;charset=UTF-8;ver=0.9";
+    private static final String COLLECTION_ELEMENT_NAME = "retentionRules";
+
+    /**
+     * Creates a RetentionRuleCollection.
+     *
+     * Use {@link RetentionRuleApi} to get RetentionRuleCollection.
+     *
+     * @param cloudOfThingsRestClient the necessary REST client to send requests to the CoT.
+     * @param relativeApiUrl          relative url of the REST API without leading slash.
+     * @param gson                    the necessary json De-/serializer.
+     * @param filterBuilder           the build criteria or null if all items should be retrieved.
+     */
+    RetentionRuleCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
+                            final String relativeApiUrl,
+                            final Gson gson,
+                            final Filter.FilterBuilder filterBuilder) {
+        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder);
+    }
+
+
+    /**
+     * Retrieves the current page.
+     * <p>
+     * Retrieves the rules influenced by filters set in construction.
+     *
+     * @return array of found rules
+     */
+    public RetentionRule[] getRetentionRules() {
+        final JsonArray jsonRules = getJsonArray();
+        return (jsonRules == null) ? null : StreamSupport.stream(getJsonArray().spliterator(), false).
+                map(rule -> new RetentionRule(gson.fromJson(rule.getAsJsonObject(), ExtensibleObject.class))).
+                toArray(RetentionRule[]::new);
+    }
+
+}

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/ExtensibleObject.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/ExtensibleObject.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * Created by Patrick Steinert on 31.01.16.
  */
 public class ExtensibleObject {
-    protected final HashMap<String, Object> anyObject = new HashMap<String, Object>();
+    protected final HashMap<String, Object> anyObject = new HashMap<>();
 
     /**
      * Constructur for use in sub classes.
@@ -70,7 +70,7 @@ public class ExtensibleObject {
     /**
      * Set a custom attribute with its name derived from class package and name.
      * <p>
-     * E.g. a class com.telekom.SpecialObject will get the identifiert com_telekom_SpecialObject.
+     * E.g. a class com.telekom.SpecialObject will get the identifier com_telekom_SpecialObject.
      *
      * @param attribute the value of the custom attribute.
      */

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/GsonUtils.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/GsonUtils.java
@@ -10,6 +10,7 @@ import com.telekom.m2m.cot.restsdk.inventory.ManagedObject;
 import com.telekom.m2m.cot.restsdk.inventory.ManagedObjectReference;
 import com.telekom.m2m.cot.restsdk.inventory.ManagedObjectReferenceCollection;
 import com.telekom.m2m.cot.restsdk.measurement.Measurement;
+import com.telekom.m2m.cot.restsdk.retentionrule.RetentionRule;
 import com.telekom.m2m.cot.restsdk.users.CurrentUser;
 import com.telekom.m2m.cot.restsdk.users.Group;
 import com.telekom.m2m.cot.restsdk.users.Role;
@@ -34,6 +35,7 @@ public class GsonUtils {
 				.registerTypeAdapter(Group.class, new ExtensibleObjectSerializer())
 				.registerTypeAdapter(CurrentUser.class, new ExtensibleObjectSerializer())
 				.registerTypeAdapter(Role.class, new ExtensibleObjectSerializer())
+				.registerTypeAdapter(RetentionRule.class, new ExtensibleObjectSerializer())
 
 				.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").create();
 	}

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -133,7 +133,7 @@ public class JsonArrayPagination {
         final JsonObject object = getJsonObject(pageCursor + 1);
         if (object.has(collectionElementName)) {
             final JsonArray jsonArray = object.get(collectionElementName).getAsJsonArray();
-            nextAvailable = jsonArray.size() > 0 ? true : false;
+            nextAvailable = (jsonArray.size() > 0);
         }
         return nextAvailable;
     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -79,7 +79,7 @@ public class JsonArrayPagination {
     /**
      * Retrieves the current page.
      * <p>
-     * Retrieves the entries influenced by filters setted in construction.
+     * Retrieves the entries influenced by filters set in construction.
      *
      * @return JsonArray of found JsonElements
      */

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApiIT.java
@@ -1,0 +1,124 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+
+import com.telekom.m2m.cot.restsdk.CloudOfThingsPlatform;
+import com.telekom.m2m.cot.restsdk.event.Event;
+import com.telekom.m2m.cot.restsdk.event.EventApi;
+import com.telekom.m2m.cot.restsdk.util.Filter;
+import com.telekom.m2m.cot.restsdk.util.TestHelper;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class RetentionRuleApiIT {
+
+    private CloudOfThingsPlatform cotPlat = new CloudOfThingsPlatform(TestHelper.TEST_HOST, TestHelper.TEST_USERNAME, TestHelper.TEST_PASSWORD);
+
+    private RetentionRuleApi retentionRuleApi = cotPlat.getRetentionRuleApi();
+
+
+    @Test
+    public void testCreateReadUpdateDeleteRule() throws Exception {
+        // given
+        RetentionRule ruleIn = new RetentionRule();
+        String source = "source-" + (Math.random() * Integer.MAX_VALUE);
+        ruleIn.setType("*");
+        ruleIn.setDataType("EVENT");  // TODO: EVENT, MEASUREMENT are ok, ALARM, AUDIT, OPERATION are not: '"retention/Invalid Data"' HTTP status code:'422'
+        ruleIn.setFragmentType("RetentionRuleApiIT");
+        ruleIn.setSource(source);
+        ruleIn.setMaximumAge(365);
+
+        // when
+        RetentionRule r = retentionRuleApi.createRetentionRule(ruleIn);
+
+        // then
+        assertNotNull(r.getId(), "Should now have an Id");
+        assertTrue(r == ruleIn);
+
+        // when
+        RetentionRule ruleOut = retentionRuleApi.getRule(ruleIn.getId());
+
+        // then
+        assertEquals(ruleIn.getId(), ruleOut.getId());
+        assertEquals(ruleIn.getSource(), ruleOut.getSource());
+        assertEquals(ruleIn.getType(), ruleOut.getType());
+        assertEquals(ruleIn.getDataType(), ruleOut.getDataType());
+        assertEquals(ruleIn.getFragmentType(), ruleOut.getFragmentType());
+        assertEquals(ruleIn.getMaximumAge(), ruleOut.getMaximumAge());
+
+        // given
+        ruleIn = ruleOut;
+        ruleIn.setMaximumAge(31);
+        ruleIn.setType("newType");
+
+        // when
+        retentionRuleApi.update(ruleIn);
+
+        // then
+        ruleOut = retentionRuleApi.getRule(ruleIn.getId());
+        assertEquals("newType", ruleOut.getType());
+        assertEquals(31, ruleOut.getMaximumAge());
+        assertEquals("EVENT", ruleOut.getDataType());
+        assertEquals("RetentionRuleApiIT", ruleOut.getFragmentType());
+
+        // when
+        retentionRuleApi.deleteRetentionRule(ruleIn);
+
+        // then
+        ruleOut = retentionRuleApi.getRule(ruleIn.getId());
+        assertNull(ruleOut);
+    }
+
+
+    @Test
+    public void testReadRules() {
+        // given
+        RetentionRule rule = new RetentionRule();
+        String source = "source-" + (Math.random() * Integer.MAX_VALUE);
+        rule.setType("1");
+        rule.setDataType("MEASUREMENT");
+        rule.setFragmentType("RetentionRuleApiIT");
+        rule.setSource(source);
+        rule.setMaximumAge(365);
+
+        long id0 = retentionRuleApi.createRetentionRule(rule).getId();
+        long id1 = retentionRuleApi.createRetentionRule(rule).getId();
+        long id2 = retentionRuleApi.createRetentionRule(rule).getId();
+        rule.setSource("foo");
+        retentionRuleApi.createRetentionRule(rule); // This is the one that should be filtered out later. TODO: doesn't work
+
+        // when
+        RetentionRuleCollection collection = retentionRuleApi.getRetentionRules();
+
+        // then
+        assertTrue(collection.getRetentionRules().length >= 4); // It's >= because we don't know what other data might already be there.
+
+        /*
+        // TODO: filter doesn't have any effect for RetentionRules?
+        collection = retentionRuleApi.getRetentionRules(Filter.build().bySource(source));
+        collection.setPageSize(100);
+        RetentionRule[] rules = collection.getRetentionRules();
+
+        assertEquals(rules.length, 3);
+        assertEquals((long)rules[0].getId(), id0);
+        assertEquals((long)rules[1].getId(), id1);
+        assertEquals((long)rules[2].getId(), id2);
+
+        // TODO: deleting collectins of RetentionRules doesn't work either and would be dangerous, without filters.
+        retentionRuleApi.deleteRetentionRules(Filter.build().bySource(source));
+
+        collection = retentionRuleApi.getRetentionRules(Filter.build().bySource(source));
+        rules = collection.getRetentionRules();
+        assertEquals(rules.length, 0);
+        */
+
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleApiIT.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 import java.util.Date;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -93,7 +94,7 @@ public class RetentionRuleApiIT {
         long id1 = retentionRuleApi.createRetentionRule(rule).getId();
         long id2 = retentionRuleApi.createRetentionRule(rule).getId();
         rule.setSource("foo");
-        retentionRuleApi.createRetentionRule(rule); // This is the one that should be filtered out later. TODO: doesn't work
+        long id3 = retentionRuleApi.createRetentionRule(rule).getId(); // This is the one that should be filtered out later. TODO: doesn't work
 
         // when
         RetentionRuleCollection collection = retentionRuleApi.getRetentionRules();
@@ -120,5 +121,10 @@ public class RetentionRuleApiIT {
         assertEquals(rules.length, 0);
         */
 
+        // cleanup
+        retentionRuleApi.deleteRetentionRule(id0);
+        retentionRuleApi.deleteRetentionRule(id1);
+        retentionRuleApi.deleteRetentionRule(id2);
+        retentionRuleApi.deleteRetentionRule(id3);
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollectionTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollectionTest.java
@@ -1,0 +1,86 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+
+import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.Filter;
+import com.telekom.m2m.cot.restsdk.util.GsonUtils;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.testng.Assert.assertEquals;
+
+
+public class RetentionRuleCollectionTest {
+
+    private RetentionRuleCollection retentionRuleCollection;
+
+    private CloudOfThingsRestClient rc = Mockito.mock(CloudOfThingsRestClient.class);
+
+    private String collectionJson = "{\n" +
+            "\"statistics\": {\n" +
+            "    \"currentPage\": 1,\n" +
+            "    \"pageSize\": 5,\n" +
+            "    \"totalPages\": 1\n" +
+            "},\n" +
+            "\"retentionRules\": [\n" +
+            "    {\n" +
+            "        \"dataType\": \"EVENT\",\n" +
+            "        \"fragmentType\": \"fragmentType1\",\n" +
+            "        \"id\": 1,\n" +
+            "        \"maximumAge\": 12,\n" +
+            "        \"self\": \"<<URL of retentionRule>>\",\n" +
+            "        \"source\": \"source\",\n" +
+            "        \"type\": \"type1\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "        \"dataType\": \"ALARM\",\n" +
+            "        \"fragmentType\": \"fragmentType2\",\n" +
+            "        \"id\": 2,\n" +
+            "        \"maximumAge\": 12,\n" +
+            "        \"self\": \"<<URL of retentionRule>>\",\n" +
+            "        \"source\": \"source\",\n" +
+            "        \"type\": \"type2\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "        \"dataType\": \"*\",\n" +
+            "        \"fragmentType\": \"*\",\n" +
+            "        \"id\": 5,\n" +
+            "        \"maximumAge\": 12,\n" +
+            "        \"self\": \"<<URL of retentionRule>>\",\n" +
+            "        \"source\": \"*\",\n" +
+            "        \"type\": \"*\"\n" +
+            "    }\n" +
+            "],\n" +
+            "\"self\": \"<<URL of current page>>\"\n" +
+            "}";
+
+
+    @BeforeMethod
+    public void setup() {
+        retentionRuleCollection = new RetentionRuleCollection(
+                rc,
+                "retention/retentions",
+                GsonUtils.createGson(),
+                (Filter.FilterBuilder)null);
+        retentionRuleCollection.setPageSize(5); // Not important, but the test should not rely on default values.
+
+        Mockito.when(rc.getResponse(eq("retention/retentions?currentPage=1&pageSize=5"), any(String.class))).thenReturn(collectionJson);
+    }
+
+
+    @Test
+    public void testGetRetentionRules() {
+        RetentionRule[] rules = retentionRuleCollection.getRetentionRules();
+
+        // Did we get enough rules?
+        assertEquals(3, rules.length);
+        // All of them (i.e. no duplicates or something like that), in the right order order?
+        assertEquals("EVENT", rules[0].getDataType());
+        assertEquals("fragmentType2", rules[1].getFragmentType());
+        assertEquals("*", rules[2].getType());
+    }
+
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollectionTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollectionTest.java
@@ -77,7 +77,7 @@ public class RetentionRuleCollectionTest {
 
         // Did we get enough rules?
         assertEquals(3, rules.length);
-        // All of them (i.e. no duplicates or something like that), in the right order order?
+        // All of them (i.e. no duplicates or something like that), in the right order?
         assertEquals("EVENT", rules[0].getDataType());
         assertEquals("fragmentType2", rules[1].getFragmentType());
         assertEquals("*", rules[2].getType());

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
@@ -17,51 +17,51 @@ public class RetentionRuleTest {
 
         Gson gson = GsonUtils.createGson();
 
-        RetentionRule rIn = new RetentionRule();
-        rIn.setId(12345678L);
-        rIn.setEditable(true);
-        rIn.setType("xx_yy_zz");
-        rIn.setDataType("aa_bb_cc");
-        rIn.setFragmentType("11_22_33");
-        rIn.setSource("the source");
-        rIn.setMaximumAge(365);
+        RetentionRule ruleIn = new RetentionRule();
+        ruleIn.setId(12345678L);
+        ruleIn.setEditable(true);
+        ruleIn.setType("xx_yy_zz");
+        ruleIn.setDataType("aa_bb_cc");
+        ruleIn.setFragmentType("11_22_33");
+        ruleIn.setSource("the source");
+        ruleIn.setMaximumAge(365);
 
         // Just to be sure, bc it's not normal trivial getters/setters:
-        assertEquals(12345678L, (long)rIn.getId());
-        assertTrue(rIn.isEditable());
-        assertEquals("xx_yy_zz", rIn.getType());
-        assertEquals("aa_bb_cc", rIn.getDataType());
-        assertEquals("11_22_33", rIn.getFragmentType());
-        assertEquals("the source", rIn.getSource());
-        assertEquals(365, (long)rIn.getMaximumAge());
+        assertEquals(12345678L, (long)ruleIn.getId());
+        assertTrue(ruleIn.isEditable());
+        assertEquals("xx_yy_zz", ruleIn.getType());
+        assertEquals("aa_bb_cc", ruleIn.getDataType());
+        assertEquals("11_22_33", ruleIn.getFragmentType());
+        assertEquals("the source", ruleIn.getSource());
+        assertEquals(365, (long)ruleIn.getMaximumAge());
 
-        String json = gson.toJson(rIn);
+        String json = gson.toJson(ruleIn);
 
-        ExtensibleObject o = gson.fromJson(json, ExtensibleObject.class);
-        RetentionRule rOut = new RetentionRule(o);
-        assertEquals(12345678L, (long)rOut.getId());
-        assertTrue(rOut.isEditable());
-        assertEquals("xx_yy_zz", rOut.getType());
-        assertEquals("aa_bb_cc", rOut.getDataType());
-        assertEquals("11_22_33", rOut.getFragmentType());
-        assertEquals("the source", rOut.getSource());
-        assertEquals(365, (long)rOut.getMaximumAge());
+        ExtensibleObject eo = gson.fromJson(json, ExtensibleObject.class);
+        RetentionRule ruleOut = new RetentionRule(eo);
+        assertEquals(12345678L, (long)ruleOut.getId());
+        assertTrue(ruleOut.isEditable());
+        assertEquals("xx_yy_zz", ruleOut.getType());
+        assertEquals("aa_bb_cc", ruleOut.getDataType());
+        assertEquals("11_22_33", ruleOut.getFragmentType());
+        assertEquals("the source", ruleOut.getSource());
+        assertEquals(365, ruleOut.getMaximumAge());
 
 
-        rIn = new RetentionRule();
-        rIn.setEditable(false);
-        rIn.setMaximumAge(7);
+        ruleIn = new RetentionRule();
+        ruleIn.setEditable(false);
+        ruleIn.setMaximumAge(7);
 
-        json = gson.toJson(rIn);
+        json = gson.toJson(ruleIn);
 
-        o = gson.fromJson(json, ExtensibleObject.class);
-        rOut = new RetentionRule(o);
-        assertNull(rOut.getId());
-        assertFalse(rOut.isEditable());
-        assertNull(rOut.getType());
-        assertNull(rOut.getDataType());
-        assertNull(rOut.getFragmentType());
-        assertNull(rOut.getSource());
-        assertEquals(7, (long)rOut.getMaximumAge());
+        eo = gson.fromJson(json, ExtensibleObject.class);
+        ruleOut = new RetentionRule(eo);
+        assertNull(ruleOut.getId());
+        assertFalse(ruleOut.isEditable());
+        assertNull(ruleOut.getType());
+        assertNull(ruleOut.getDataType());
+        assertNull(ruleOut.getFragmentType());
+        assertNull(ruleOut.getSource());
+        assertEquals(7, (long)ruleOut.getMaximumAge());
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 public class RetentionRuleTest {
 
     @Test
-    public void testEventSerialization() {
+    public void testRetentionRuleSerialization() {
 
         Gson gson = GsonUtils.createGson();
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleTest.java
@@ -1,0 +1,67 @@
+package com.telekom.m2m.cot.restsdk.retentionrule;
+
+import com.google.gson.Gson;
+import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
+import com.telekom.m2m.cot.restsdk.util.GsonUtils;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class RetentionRuleTest {
+
+    @Test
+    public void testEventSerialization() {
+
+        Gson gson = GsonUtils.createGson();
+
+        RetentionRule rIn = new RetentionRule();
+        rIn.setId(12345678L);
+        rIn.setEditable(true);
+        rIn.setType("xx_yy_zz");
+        rIn.setDataType("aa_bb_cc");
+        rIn.setFragmentType("11_22_33");
+        rIn.setSource("the source");
+        rIn.setMaximumAge(365);
+
+        // Just to be sure, bc it's not normal trivial getters/setters:
+        assertEquals(12345678L, (long)rIn.getId());
+        assertTrue(rIn.isEditable());
+        assertEquals("xx_yy_zz", rIn.getType());
+        assertEquals("aa_bb_cc", rIn.getDataType());
+        assertEquals("11_22_33", rIn.getFragmentType());
+        assertEquals("the source", rIn.getSource());
+        assertEquals(365, (long)rIn.getMaximumAge());
+
+        String json = gson.toJson(rIn);
+
+        ExtensibleObject o = gson.fromJson(json, ExtensibleObject.class);
+        RetentionRule rOut = new RetentionRule(o);
+        assertEquals(12345678L, (long)rOut.getId());
+        assertTrue(rOut.isEditable());
+        assertEquals("xx_yy_zz", rOut.getType());
+        assertEquals("aa_bb_cc", rOut.getDataType());
+        assertEquals("11_22_33", rOut.getFragmentType());
+        assertEquals("the source", rOut.getSource());
+        assertEquals(365, (long)rOut.getMaximumAge());
+
+
+        rIn = new RetentionRule();
+        rIn.setEditable(false);
+        rIn.setMaximumAge(7);
+
+        json = gson.toJson(rIn);
+
+        o = gson.fromJson(json, ExtensibleObject.class);
+        rOut = new RetentionRule(o);
+        assertNull(rOut.getId());
+        assertFalse(rOut.isEditable());
+        assertNull(rOut.getType());
+        assertNull(rOut.getDataType());
+        assertNull(rOut.getFragmentType());
+        assertNull(rOut.getSource());
+        assertEquals(7, (long)rOut.getMaximumAge());
+    }
+}


### PR DESCRIPTION
The retention rules REST API is less friendly than some other types. It doesn't seem to support any filters and as a consequence no deletion of a collection either.
There's also the problem that not all dataTypes can be created via the REST API. Only EVENT and MEASUREMENT seem to work.
Apart from that it's mostly straight forward.
