### PR TITLE
Binary check for filters

### DIFF
--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesApi.java
@@ -2,6 +2,7 @@ package com.telekom.m2m.cot.restsdk.inventory;
 
 import com.google.gson.Gson;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.Filter;
 import com.telekom.m2m.cot.restsdk.util.GsonUtils;
 
 /**
@@ -23,18 +24,19 @@ public class BinariesApi {
     /**
      * Retrieves binaries meta data.
      *
-     * TODO: can we use any filters for binaries?
      * @param pageSize size of the result page (Max. 2000); null = use default ({@link com.telekom.m2m.cot.restsdk.util.JsonArrayPagination#DEFAULT_PAGE_SIZE}
+     *@param filters the build criteria or null if all items should be retrieved
      * @return the pageable BinariesCollection
      */
-    public BinariesCollection getBinaries(Integer pageSize) {
-        return new BinariesCollection(
+
+    
+    public BinariesCollection getBinaries(Filter.FilterBuilder filters,Integer pageSize) {
+        return new BinariesCollection(filters,
                 cloudOfThingsRestClient,
                 RELATIVE_API_URL,
                 gson,
                 pageSize);
     }
-
 
     /**
      * Upload/create a new Binary.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
@@ -3,6 +3,7 @@ package com.telekom.m2m.cot.restsdk.inventory;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.Filter;
 import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
 
 
@@ -15,16 +16,19 @@ public class BinariesCollection extends JsonArrayPagination {
     private static final String COLLECTION_ELEMENT_NAME = "managedObjects";
 
 
-    public BinariesCollection(CloudOfThingsRestClient cloudOfThingsRestClient,
-                              String relativeApiUrl,
-                              Gson gson,
-                              Integer pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, null);
-        if (pageSize != null) {
-            setPageSize(pageSize);
-        }
-    }
 
+    
+    public BinariesCollection(Filter.FilterBuilder filters,CloudOfThingsRestClient cloudOfThingsRestClient,
+            String relativeApiUrl,
+            Gson gson,
+            Integer pageSize) {
+super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filters);
+if (pageSize != null) {
+setPageSize(pageSize);
+}
+}
+    
+    
     /**
      * Retrieves the current page.
      * <p>

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
@@ -17,16 +17,13 @@ public class BinariesCollection extends JsonArrayPagination {
 
 
 
-    
-    public BinariesCollection(Filter.FilterBuilder filters,CloudOfThingsRestClient cloudOfThingsRestClient,
-            String relativeApiUrl,
-            Gson gson,
-            Integer pageSize) {
-super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filters);
-if (pageSize != null) {
-setPageSize(pageSize);
-}
-}
+	public BinariesCollection(Filter.FilterBuilder filters, CloudOfThingsRestClient cloudOfThingsRestClient,
+			String relativeApiUrl, Gson gson, Integer pageSize) {
+		super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filters);
+		if (pageSize != null) {
+			setPageSize(pageSize);
+		}
+	}
     
     
     /**

--- a/src/test/java/com/telekom/m2m/cot/restsdk/inventory/BinariesApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/inventory/BinariesApiIT.java
@@ -93,7 +93,7 @@ public class BinariesApiIT {
         binaryIds.add(binaryId);
 
 
-        BinariesCollection c = api.getBinaries(1000);
+        BinariesCollection c = api.getBinaries(null,1000);
         Binary[] bb = c.getBinaries();
 
         // We can't know how many other binaries were there already.
@@ -115,4 +115,45 @@ public class BinariesApiIT {
         assertTrue(foundA);
         assertTrue(foundB);
     }
+    
+    @Test
+    public void testGetCollectionWithFilters() {
+		// A quick test that checks if binaries work with filters at all. Here, we are
+		// going to try the "filter by type" feature as it is known to work with most of
+		// the other objects:
+    	
+    	// Let's upload two binaries with different types:
+        String filenameA = "myFileA-"+System.currentTimeMillis();
+        Binary bin = new Binary(filenameA, "text/plain", "blablabla\nfoobar\nyolo\n".getBytes());
+        String binaryId = api.uploadBinary(bin);
+        binaryIds.add(binaryId);
+    
+        
+        String filenameB = "myFileB-"+System.currentTimeMillis();
+        bin = new Binary(filenameB, "application/xml", "<xml>whatever<tag n=1/></xml>".getBytes());
+        binaryId = api.uploadBinary(bin);
+        binaryIds.add(binaryId);
+   
+        //Now let's create two distinct binary collections using the filter "type":
+        Filter.FilterBuilder filterBuilderForTextType = Filter.build().byType("text/plain");
+        BinariesCollection textTypeCollection =api.getBinaries(filterBuilderForTextType , 1000);
+        
+        Filter.FilterBuilder filterBuilderForXmlType = Filter.build().byType("application/xml");
+        BinariesCollection xmlTypeCollection =api.getBinaries(filterBuilderForXmlType , 1000);
+            
+        Binary[] textTypeArray=textTypeCollection.getBinaries();
+        Binary[] xmlTypeArray=xmlTypeCollection.getBinaries();
+        
+        
+        // Now each collection has to contain only the binaries with their filtered types:
+        for(Binary textBinary : textTypeArray){
+        	assertEquals(textBinary.getType(), "text/plain");
+        }
+    
+        for(Binary xmlBinary : xmlTypeArray){
+        	assertEquals(xmlBinary.getType(), "application/xml");
+        }
+    }
+    
+    
 }


### PR DESCRIPTION
Filtering feature is implemented for the binaries and the integration tests show that the binaries can work with filters. Not all filter types are tested. This was an attempt to see whether binaries can be filtered at all or not.